### PR TITLE
Theming compatible, small UI fixes, request body fix

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+readme_images

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 readme_images
+scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+> **Attention:** ⚠️ means that a change breaks things. Manual adjustments will be necessary. So be careful before updating. Even data loss might occur.
+
+**Version 1.1.3 (19th of December 2024)**
+- added missing path and cookie selection
+- added links to official openAPI documentation
+
+**Version 1.1.2 (18th of July 2024)**
+- updated dependencies
+- Theme compatibility
+- UI fixes (fixed label / input field lengths)
+- Using full URL for the swagger-ui-tab
+- Warning for "GET", "HEAD" and "DELETE" in request body tab

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digital-tvilling/node-red-openapi-generator",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "A set of tools for generating OpenAPI3/Swagger documentation based on the HTTP nodes deployed in a flow. An updated version of the Node-RED Swagger Documentation Generator to support OpenAPI3.",
     "license": "Apache",
     "repository": {
@@ -28,14 +28,17 @@
         "Filip Åsblom <asblom@gmail.com>"
     ],
     "dependencies": {
-        "i18next": "^23.11.5",
-        "swagger-ui": "^5.17.14",
-        "swagger-ui-dist": "^5.17.14"
+        "i18next": "^23.16.8",
+        "swagger-ui": "^5.18.2",
+        "swagger-ui-dist": "^5.18.2"
     },
     "devDependencies": {
         "eslint": "^ 9.5.0"
     },
     "engines": {
         "node": ">=18.0.0"
-      }
+    },
+    "scripts": {
+        "setup": "./scripts/setup.sh"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digital-tvilling/node-red-openapi-generator",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "A set of tools for generating OpenAPI3/Swagger documentation based on the HTTP nodes deployed in a flow. An updated version of the Node-RED Swagger Documentation Generator to support OpenAPI3.",
     "license": "Apache",
     "repository": {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Install dependencies
+npm install
+# Initialize sample project
+mkdir -p /home/gitpod/.node-red
+cd /home/gitpod/.node-red/
+npm install
+npm link /workspace/node-red-openapi-generator --save
+
+# Go back to workspace directory
+cd /workspace/node-red-openapi-generator

--- a/swagger/swagger-ui/swagger-ui.html
+++ b/swagger/swagger-ui/swagger-ui.html
@@ -17,7 +17,7 @@
       // get full url with node-RED settings (like original node-red-node-swagger)
       const parentLocation = window.parent.location
       swaggerDocUrl = parentLocation.protocol + "//" + parentLocation.hostname + ":" + parentLocation.port + window.parent.RED.settings.httpNodeRoot 
-      if (!swaggerDocUrl.endsWith('/') {
+      if (!swaggerDocUrl.endsWith('/')) {
         swaggerDocUrl =+ "/";
       }
       swaggerDocUrl =+ "http-api/swagger.json";

--- a/swagger/swagger-ui/swagger-ui.html
+++ b/swagger/swagger-ui/swagger-ui.html
@@ -16,7 +16,11 @@
     if (window.parent) {
       // get full url with node-RED settings (like original node-red-node-swagger)
       const parentLocation = window.parent.location
-      swaggerDocUrl = parentLocation.protocol + "//" + parentLocation.hostname + ":" + parentLocation.port + window.parent.RED.settings.httpNodeRoot + "http-api/swagger.json";
+      swaggerDocUrl = parentLocation.protocol + "//" + parentLocation.hostname + ":" + parentLocation.port + window.parent.RED.settings.httpNodeRoot 
+      if (!swaggerDocUrl.endsWith('/') {
+        swaggerDocUrl =+ "/";
+      }
+      swaggerDocUrl =+ "http-api/swagger.json";
     }
 
     const ui = SwaggerUIBundle({

--- a/swagger/swagger-ui/swagger-ui.html
+++ b/swagger/swagger-ui/swagger-ui.html
@@ -12,8 +12,15 @@
   <script src="swagger-ui-standalone-preset.js"></script> 
   <script>
   window.onload = function() {
+    let swaggerDocUrl = "http-api/swagger.json";
+    if (window.parent) {
+      // get full url with node-RED settings (like original node-red-node-swagger)
+      const parentLocation = window.parent.location
+      swaggerDocUrl = parentLocation.protocol + "//" + parentLocation.hostname + ":" + parentLocation.port + window.parent.RED.settings.httpNodeRoot + "http-api/swagger.json";
+    }
+
     const ui = SwaggerUIBundle({
-      url: "/http-api/swagger.json", 
+      url: swaggerDocUrl, 
       dom_id: '#swagger-ui',
       deepLinking: true,
       presets: [

--- a/swagger/swagger-ui/swagger-ui.html
+++ b/swagger/swagger-ui/swagger-ui.html
@@ -18,9 +18,9 @@
       const parentLocation = window.parent.location
       swaggerDocUrl = parentLocation.protocol + "//" + parentLocation.hostname + ":" + parentLocation.port + window.parent.RED.settings.httpNodeRoot 
       if (!swaggerDocUrl.endsWith('/')) {
-        swaggerDocUrl =+ "/";
+        swaggerDocUrl += "/";
       }
-      swaggerDocUrl =+ "http-api/swagger.json";
+      swaggerDocUrl += "http-api/swagger.json";
     }
 
     const ui = SwaggerUIBundle({

--- a/swagger/swagger.html
+++ b/swagger/swagger.html
@@ -28,7 +28,7 @@
   <div id="node-config-swagger-tabs-content" style="min-height: 350px">
       <div id="swagger-tab-info">
           <div class="form-row">
-              <label id="node-config-input-summary-label" for="node-config-input-summary" class="popover-right node-swagger-full-label-width" data-i18n="[data-content]swagger.data-content.summary"><span data-i18n="swagger.label.summary"></span></label>
+              <label id="node-config-input-summary-label" for="node-config-input-summary" class="popover-right" data-i18n="[data-content]swagger.data-content.summary"><span data-i18n="swagger.label.summary"></span></label>
               <input type="text" id="node-config-input-summary">
           </div>
           <div class="form-row">
@@ -62,6 +62,9 @@
           </div>
       </div>
       <div id="swagger-tab-requestBody">
+        <div id="swagger-method-requestBody-warning" class="hide">
+          <i class="fa fa-warning" style="margin-right: 6px"></i> Methods like "GET", "HEAD" or "DELETE" should not have a request body.
+        </div>
         <div class="form-row">
             <label id="node-config-input-requestBody-label" for="node-config-input-requestBody" class="popover-right node-swagger-full-label-width"><span>Request Body Description</span></label>
             <input type="text" id="node-config-input-requestBody-description" style="width:100%;">
@@ -695,6 +698,11 @@
       setTimeout(function () {
         tabs.resize();
       }, 10);
+
+      // show / hide request body warning for some methods
+      if (["GET", "HEAD", "DELETE"].includes($("#node-config-input-method").text())) {
+        $("#swagger-method-requestBody-warning")[0]?.classList?.remove("hide")
+      }
     }
 
     RED.nodes.registerType("swagger-doc", {
@@ -1056,5 +1064,9 @@
   .node-swagger-prop-name-label {
     width: 100px;
     margin-right: 10px;
+  }
+  #swagger-method-requestBody-warning {
+    margin: 20px 0;
+    color: var(--red-ui-text-color-warning);
   }
 </style>

--- a/swagger/swagger.html
+++ b/swagger/swagger.html
@@ -75,7 +75,7 @@
             <input type="text" id="node-config-input-requestBody-contentType" value="application/json" style="width: 100%;">
         </div>
         <div class="form-row">
-            <label id="node-config-input-requestBody-json-label" for="node-config-input-requestBody-json" class="popover-right"><span>Request Body JSON Schema</span></label>
+            <label id="node-config-input-requestBody-json-label" for="node-config-input-requestBody-json" class="popover-right node-swagger-full-label-width"><span>Request Body JSON Schema</span></label>
             <textarea id="node-config-input-requestBody-json" style="width:100%; height: 200px;"></textarea>
         </div>
     </div>
@@ -1049,8 +1049,9 @@
     float: right; 
     vertical-align: middle;
   }
-  .node-swagger-full-label-width {
-    width: auto;
+  .form-row label.node-swagger-full-label-width {
+    width: fit-content;
+    text-wrap: nowrap;
   }
   .node-swagger-prop-name-label {
     width: 100px;

--- a/swagger/swagger.html
+++ b/swagger/swagger.html
@@ -88,7 +88,6 @@
 </script>
 
 <script type="text/javascript">
-  var swaggerDocUrl;
   (function () {
     function createPropertyRow(opts) {
       var row = $("<div/>", {
@@ -727,15 +726,6 @@
           style:
             "position: relative; padding: 0px 4px; height: 100%; overflow: hidden",
         });
-
-        swaggerDocUrl =
-          window.location.protocol +
-          "//" +
-          window.location.hostname +
-          ":" +
-          window.location.port +
-          RED.settings.httpNodeRoot +
-          "http-api/swagger.json";
         var swaggerFrame = $("<iframe/>", {
           id: "swagger-ui-frame",
           style:

--- a/swagger/swagger.html
+++ b/swagger/swagger.html
@@ -22,13 +22,13 @@
   </div>
 
   <div class="form-row">
-      <ul style="background: #fff; min-width: 600px; margin-bottom: 20px;" id="node-config-swagger-tabs"></ul>
+      <ul style="min-width: 600px; margin-bottom: 20px;" id="node-config-swagger-tabs"></ul>
   </div>
 
   <div id="node-config-swagger-tabs-content" style="min-height: 350px">
       <div id="swagger-tab-info">
           <div class="form-row">
-              <label id="node-config-input-summary-label" for="node-config-input-summary" class="popover-right" data-i18n="[data-content]swagger.data-content.summary"><span data-i18n="swagger.label.summary"></span></label>
+              <label id="node-config-input-summary-label" for="node-config-input-summary" class="popover-right node-swagger-full-label-width" data-i18n="[data-content]swagger.data-content.summary"><span data-i18n="swagger.label.summary"></span></label>
               <input type="text" id="node-config-input-summary">
           </div>
           <div class="form-row">
@@ -45,7 +45,7 @@
       </div>
       <div id="swagger-tab-parameters">
           <div class="form-row" style="box-sizing: border-box; border-radius: 5px; height: 310px; padding: 5px; border: 1px solid #ccc; overflow-y:scroll;">
-              <ul id="node-config-parameter-list" style="padding: 0; margin:0;"></ul>
+              <ul id="node-config-parameter-list" class="red-ui-editableList-list" style="padding: 0; margin:0;"></ul>
           </div>
           <div class="form-row">
               <a href="#" class="red-ui-button red-ui-button-small" id="node-config-input-add-parameter"><i class="fa fa-plus"></i> <span data-i18n="swagger.label.parameter"></span></a>
@@ -54,7 +54,7 @@
       </div>
       <div id="swagger-tab-responses">
           <div class="form-row" style="box-sizing: border-box; border-radius: 5px; height: 310px; padding: 5px; border: 1px solid #ccc; overflow-y:scroll;">
-              <ul id="node-config-response-list" style="padding: 0; margin:0;"></ul>
+              <ul id="node-config-response-list" class="red-ui-editableList-list" style="padding: 0; margin:0;"></ul>
           </div>
           <div class="form-row">
               <a href="#" class="red-ui-button red-ui-button-small" id="node-config-input-add-response"><i class="fa fa-plus"></i> <span data-i18n="swagger.label.response"></span></a>
@@ -63,7 +63,7 @@
       </div>
       <div id="swagger-tab-requestBody">
         <div class="form-row">
-            <label id="node-config-input-requestBody-label" for="node-config-input-requestBody" class="popover-right"><span>Request Body Description</span></label>
+            <label id="node-config-input-requestBody-label" for="node-config-input-requestBody" class="popover-right node-swagger-full-label-width"><span>Request Body Description</span></label>
             <input type="text" id="node-config-input-requestBody-description" style="width:100%;">
         </div>
         <div class="form-row">
@@ -92,11 +92,9 @@
     function createPropertyRow(opts) {
       var row = $("<div/>", {
         class: "node-swagger-property-name-row",
-        style: "margin-top: 3px; margin-left: 10px;",
       });
       $("<label/>", {
         class: "node-swagger-prop-name-label",
-        style: "width: auto; margin-right: 10px;",
       })
         .text("Name")
         .appendTo(row);
@@ -109,8 +107,7 @@
         .appendTo(row);
       var remove = $("<a/>", {
         href: "#",
-        class: "red-ui-button red-ui-button-small",
-        style: "float: right; margin-right: 5px; margin-top: 3px;",
+        class: "red-ui-button red-ui-button-small node-swagger-remove-button",
       }).appendTo(row);
       $("<i/>", { class: "fa fa-remove" }).appendTo(remove);
       remove.click(function (e) {
@@ -120,8 +117,7 @@
         e.preventDefault();
       });
       var propList = $("<div/>", {
-        class: "node-swagger-property-row",
-        style: "margin-top: 3px; margin-left: 10px;",
+        class: "node-swagger-property-row"
       });
       propList.appendTo(row);
       opts.propertyRow = true;
@@ -206,17 +202,16 @@
     }
 
     function createParameterLine(opts, expand) {
-      var li = $("<li/>", {
-        style: "background: #fff; margin:4px 0; border: 1px solid #ccc;",
+      var li = $("<li />", {
+        class: "red-ui-editableList-item-removable node-swagger-item"
       }).appendTo("#node-config-parameter-list");
 
       var row1 = $("<div/>", {
-        style: "background:#f3f3f3; padding: 5px;",
+        class: "red-ui-editableList-item-content node-swagger-item-content"
       }).appendTo(li);
       var remove = $("<a/>", {
         href: "#",
-        class: "red-ui-button red-ui-button-small",
-        style: "float: right; margin-right: 5px; margin-top: 3px;",
+        class: "red-ui-button red-ui-button-small node-swagger-remove-button"
       }).appendTo(row1);
       $("<i/>", { class: "fa fa-remove" }).appendTo(remove);
       remove.click(function (e) {
@@ -334,12 +329,11 @@
       var required = $("<input/>", {
         type: "checkbox",
         class: "node-swagger-required",
-        style:
-          "width: auto; float: right; margin-left: 10px; vertical-align: middle",
+        style: "margin-left: 10px; margin-top: 10px;",
       }).appendTo(row2);
       $("<label/>", {
-        style:
-          "width: auto; float: right; margin-left:20px; vertical-align: middle",
+        class: "node-swagger-required-label",
+        style: "margin-top: 6px",
       })
         .text("Required")
         .appendTo(row2);
@@ -429,16 +423,15 @@
 
     function createResponseLine(opts, expand) {
       var li = $("<li/>", {
-        style: "background: #fff; margin:4px 0; border: 1px solid #ccc;",
+        class: "red-ui-editableList-item-removable node-swagger-item"
       }).appendTo("#node-config-response-list");
 
       var row1 = $("<div/>", {
-        style: "background:#f3f3f3; padding: 5px;",
+        class: "red-ui-editableList-item-content node-swagger-item-content"
       }).appendTo(li);
       var remove = $("<a/>", {
         href: "#",
-        class: "red-ui-button red-ui-button-small",
-        style: "float: right; margin-right: 5px; margin-top: 3px;",
+        class: "red-ui-button red-ui-button-small node-swagger-remove-button"
       }).appendTo(row1);
       $("<i/>", { class: "fa fa-remove" }).appendTo(remove);
       remove.click(function (e) {
@@ -574,16 +567,15 @@
 
     function createRequestBodyLine(opts, expand) {
       var li = $("<li/>", {
-        style: "background: #fff; margin:4px 0; border: 1px solid #ccc;",
+        class: "red-ui-editableList-item-removable node-swagger-item"
       }).appendTo("#node-config-requestBody-properties");
 
       var row1 = $("<div/>", {
-        style: "background:#f3f3f3; padding: 5px;",
+        class: "red-ui-editableList-item-content node-swagger-item-content"
       }).appendTo(li);
       var remove = $("<a/>", {
         href: "#",
-        class: "red-ui-button red-ui-button-small",
-        style: "float: right; margin-right: 5px; margin-top: 3px;",
+        class: "red-ui-button red-ui-button-small node-swagger-remove-button"
       }).appendTo(row1);
       var removeIcon = $("<i/>", {
         class: "fa fa-remove",
@@ -1034,3 +1026,34 @@
     });
   })();
 </script>
+
+<style>
+  .node-swagger-item {
+    margin: 4px 0;
+    border: 1px solid var(--red-ui-secondary-border-color);
+  }
+  .node-swagger-item-content {
+    padding: 5px;
+  }
+  .node-swagger-property-name-row, .node-swagger-property-row {
+    margin-top: 3px; 
+    margin-left: 10px;
+  }
+  a.red-ui-button.node-swagger-remove-button {
+    float: right;
+    margin-right: 5px;
+    margin-top: 7px;
+  }
+  .node-swagger-name-row input.node-swagger-required, .node-swagger-name-row label.node-swagger-required-label {
+    width: auto;
+    float: right; 
+    vertical-align: middle;
+  }
+  .node-swagger-full-label-width {
+    width: auto;
+  }
+  .node-swagger-prop-name-label {
+    width: 100px;
+    margin-right: 10px;
+  }
+</style>

--- a/swagger/swagger.html
+++ b/swagger/swagger.html
@@ -44,21 +44,21 @@
           </div>
       </div>
       <div id="swagger-tab-parameters">
-          <div class="form-row" style="box-sizing: border-box; border-radius: 5px; height: 310px; padding: 5px; border: 1px solid #ccc; overflow-y:scroll;">
+          <div class="form-row" style="box-sizing: border-box; border-radius: 5px; height: 600px; padding: 5px; border: 1px solid #ccc; overflow-y:scroll;">
               <ul id="node-config-parameter-list" class="red-ui-editableList-list" style="padding: 0; margin:0;"></ul>
           </div>
           <div class="form-row">
               <a href="#" class="red-ui-button red-ui-button-small" id="node-config-input-add-parameter"><i class="fa fa-plus"></i> <span data-i18n="swagger.label.parameter"></span></a>
-              <a href="#" id="node-config-input-parameter-info" class="popover-closable" style="font-size: 10px; text-decoration: underline; float: right"><span data-i18n="swagger.label.parameters-help"></span></a>
+              <a href="https://swagger.io/specification/#parameter-object" target="_blank" id="node-config-input-parameter-info" class="popover-closable" style="font-size: 10px; text-decoration: underline; float: right"><span data-i18n="swagger.label.parameters-help"></span></a>
           </div>
       </div>
       <div id="swagger-tab-responses">
-          <div class="form-row" style="box-sizing: border-box; border-radius: 5px; height: 310px; padding: 5px; border: 1px solid #ccc; overflow-y:scroll;">
+          <div class="form-row" style="box-sizing: border-box; border-radius: 5px; height: 600px; padding: 5px; border: 1px solid #ccc; overflow-y:scroll;">
               <ul id="node-config-response-list" class="red-ui-editableList-list" style="padding: 0; margin:0;"></ul>
           </div>
           <div class="form-row">
               <a href="#" class="red-ui-button red-ui-button-small" id="node-config-input-add-response"><i class="fa fa-plus"></i> <span data-i18n="swagger.label.response"></span></a>
-              <a href="#" id="node-config-input-response-info" class="popover-closable" style="font-size: 10px; text-decoration: underline; float: right"><span data-i18n="swagger.label.responses-help"></span></a>
+              <a href="https://swagger.io/specification/#response-object" target="_blank" id="node-config-input-response-info" class="popover-closable" style="font-size: 10px; text-decoration: underline; float: right"><span data-i18n="swagger.label.responses-help"></span></a>
           </div>
       </div>
       <div id="swagger-tab-requestBody">
@@ -306,7 +306,7 @@
         class: "node-swagger-in-select",
         style: "max-width: 150px",
       }).appendTo(inSpan);
-      ["query", "header"].forEach(function (opt) {
+      ["header", "path", "query", "cookie"].forEach(function (opt) {
         inSelect.append($("<option></option>").val(opt).text(opt));
       });
       inSelect.val(opts.in);

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -79,13 +79,16 @@ module.exports = function (RED) {
           );
           if (!resp.paths[endPoint]) resp.paths[endPoint] = {};
 
+          // request body is permitted in methods GET, HEAD, DELETE but should be avoided https://swagger.io/specification/#operation-object
+          // editors will show invalid if those methods have an request body -> if not explicit set, do not set it
+          const avoidRequestBody = ['get', 'head', 'delete']
           const {
             summary = swaggerDocNode.summary || name || method + " " + endPoint,
             description = swaggerDocNode.description || "",
             tags = swaggerDocNode.tags || "",
             deprecated = swaggerDocNode.deprecated || false,
             parameters = swaggerDocNode.parameters || [],
-            requestBody = swaggerDocNode.requestBody || {},
+            requestBody = swaggerDocNode.requestBody || (avoidRequestBody.includes(method.toLowerCase()) ? undefined : {}),
           } = swaggerDocNode;
 
           const aryTags = csvStrToArray(tags);


### PR DESCRIPTION
Hi,
thanks for updating the swagger generator. Wanted to do it by myself some times, but other projects had more priority ._.

I have some fixes, some are still from the old main version.

Theming compatible:
- Uses now the NR color coding (var(--red-....) instead of fix colors

UI fixes:
- removed some styles and set them to a class (if used more than once)
- fixed label / input field lengths

Full URL for the swagger-ui-tab: 
- Your relative URL did not use RED.settings.httpNodeRoot. Therefore the URL could be wrong. Based now on the working original code.

Request body: 
- "GET", "HEAD" and "DELETE" can have a request body but should be avoided -> [openApi specs](https://swagger.io/specification/#operation-object)
- Therefor I added a warning to the tab if it is one of those methods and remove the request body from the created file if not set. (As this would also cause an invalid warning in the swagger-ui-tab).


Best regards and have a nice day.